### PR TITLE
fix: canvas black band on tall windows

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="editor/editor.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; }
     body { background: #000; overflow: hidden; }
   </style>
   <script type="importmap">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <title>Armymen RTS</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; }
     body { background: #000; overflow: hidden; font-family: system-ui, sans-serif; }
     .resource-bar {
       position: fixed; top: 12px; left: 50%; transform: translateX(-50%);


### PR DESCRIPTION
## Summary
- Add `html, body { width: 100%; height: 100%; }` to both `index.html` and `editor.html`
- Without this, `document.body.clientHeight` only reflected content height, not the viewport — the `ResizeObserver` in `engine/game.js` read a clamped value, leaving a black band at the bottom on tall windows

Closes #34

## Test plan
- [ ] Open the game, drag the window bottom edge past 1080px — canvas should fill the entire viewport with no black band
- [ ] Check the editor as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)