### PR TITLE
fix: wait-time fairness for WorkManager (closes #33)

### DIFF
--- a/engine/game.js
+++ b/engine/game.js
@@ -5,6 +5,7 @@ export class Game {
   constructor({ container = document.body } = {}) {
     this.gameObjects     = [];
     this._lastTime       = 0;
+    this.elapsed         = 0;  // cumulative game time in seconds
     this.camera          = null;
     this._container      = container;
     this._sceneListeners = new Set();
@@ -85,6 +86,7 @@ export class Game {
   _tick(time) {
     const dt = Math.min((time - this._lastTime) / 1000, 0.1);
     this._lastTime = time;
+    this.elapsed += dt;
     for (const go of this.gameObjects) go.update(dt);
     this.onTick?.(dt);
     if (this.camera) this.renderer.render(this.scene, this.camera);

--- a/game/work_manager.js
+++ b/game/work_manager.js
@@ -6,6 +6,11 @@ import { FarmPlot } from './components/farm_plot.js';
 // or one seed delivery at a time is enough).
 const MAX_CLAIMS = { harvest: 2, tend: 1, seed: 1 };
 
+// Fairness weight: how quickly wait-time overtakes distance advantage.
+// Score = distance² / (1 + waitSeconds * FAIRNESS_K).  Higher K means older
+// tasks get prioritised more aggressively over nearer ones.
+const FAIRNESS_K = 0.3;
+
 // Central authority that hands out work. Tasks are derived from current
 // game state on demand (no separate task queue), so they can never go stale.
 //
@@ -41,26 +46,32 @@ export class WorkManager {
     this._resourceNodes = []; // gameObjects with a ResourceNode component
     this._farmPlots     = []; // gameObjects with a FarmPlot component
 
+    // Fairness: track when each (target, kind) first became eligible.
+    // Key format: gameObject instance → Map<kind, timestampSeconds>.
+    this._eligibleSince = new Map();
+
     game.addSceneListener(() => { this._dirty = true; });
   }
 
   request(ant) {
     this.release(ant);
     this._refreshCaches();
+    this._updateEligibility();
 
+    const now = this._game.elapsed ?? 0;
     const counts = new Map();
     for (const c of this._claims.values()) {
       counts.set(c.target, (counts.get(c.target) ?? 0) + 1);
     }
 
-    let best = null, bestD = Infinity;
+    let best = null, bestScore = Infinity;
 
     for (const go of this._resourceNodes) {
       const rn = go.getComponent(ResourceNode);
       if (!rn || rn.isEmpty) continue;
       if ((counts.get(go) ?? 0) >= MAX_CLAIMS.harvest) continue;
-      const d = this._dist2(ant, go);
-      if (d < bestD) { best = { kind: 'harvest', target: go, type: rn.type }; bestD = d; }
+      const score = this._fairScore(ant, go, 'harvest', now);
+      if (score < bestScore) { best = { kind: 'harvest', target: go, type: rn.type }; bestScore = score; }
     }
 
     for (const go of this._farmPlots) {
@@ -68,14 +79,14 @@ export class WorkManager {
       if (!fp) continue;
       const used = counts.get(go) ?? 0;
       if (fp.needsSeed() && used < MAX_CLAIMS.seed) {
-        const d = this._dist2(ant, go);
-        if (d < bestD) { best = { kind: 'seed', target: go }; bestD = d; }
+        const score = this._fairScore(ant, go, 'seed', now);
+        if (score < bestScore) { best = { kind: 'seed', target: go }; bestScore = score; }
       } else if (fp.needsAttention() && used < MAX_CLAIMS.tend) {
-        const d = this._dist2(ant, go);
-        if (d < bestD) { best = { kind: 'tend', target: go }; bestD = d; }
+        const score = this._fairScore(ant, go, 'tend', now);
+        if (score < bestScore) { best = { kind: 'tend', target: go }; bestScore = score; }
       } else if (fp.isReadyToHarvest() && used < MAX_CLAIMS.harvest) {
-        const d = this._dist2(ant, go);
-        if (d < bestD) { best = { kind: 'harvest', target: go, type: fp.yieldType() }; bestD = d; }
+        const score = this._fairScore(ant, go, 'harvest', now);
+        if (score < bestScore) { best = { kind: 'harvest', target: go, type: fp.yieldType() }; bestScore = score; }
       }
     }
 
@@ -144,6 +155,52 @@ export class WorkManager {
       if (go.getComponent(FarmPlot))     this._farmPlots.push(go);
     }
     this._dirty = false;
+  }
+
+  // Weighted score: distance² discounted by how long the task has been waiting.
+  _fairScore(ant, target, kind, now) {
+    const d2 = this._dist2(ant, target);
+    const kinds = this._eligibleSince.get(target);
+    const since = kinds?.get(kind) ?? now;
+    const age = now - since;
+    return d2 / (1 + age * FAIRNESS_K);
+  }
+
+  // Update the eligibility timestamps: record when targets first become valid,
+  // and clear entries for targets that are no longer valid.
+  _updateEligibility() {
+    const now = this._game.elapsed ?? 0;
+
+    // Helper: mark (target, kind) as eligible starting now if not already tracked.
+    const mark = (target, kind) => {
+      let kinds = this._eligibleSince.get(target);
+      if (!kinds) { kinds = new Map(); this._eligibleSince.set(target, kinds); }
+      if (!kinds.has(kind)) kinds.set(kind, now);
+    };
+    // Helper: clear (target, kind) eligibility.
+    const clear = (target, kind) => {
+      const kinds = this._eligibleSince.get(target);
+      if (kinds) kinds.delete(kind);
+    };
+
+    for (const go of this._resourceNodes) {
+      const rn = go.getComponent(ResourceNode);
+      if (rn && !rn.isEmpty) mark(go, 'harvest');
+      else clear(go, 'harvest');
+    }
+
+    for (const go of this._farmPlots) {
+      const fp = go.getComponent(FarmPlot);
+      if (!fp) continue;
+      if (fp.needsSeed()) mark(go, 'seed'); else clear(go, 'seed');
+      if (fp.needsAttention()) mark(go, 'tend'); else clear(go, 'tend');
+      if (fp.isReadyToHarvest()) mark(go, 'harvest'); else clear(go, 'harvest');
+    }
+
+    // Prune entries for removed gameObjects.
+    for (const go of this._eligibleSince.keys()) {
+      if (!this._game.gameObjects.includes(go)) this._eligibleSince.delete(go);
+    }
   }
 
   _dist2(ant, target) {


### PR DESCRIPTION
## Summary
- Adds wait-time aware scoring to `WorkManager.request()` so distant farms/resources are no longer starved by closer ones.
- Tracks per-target eligibility start time (`_eligibleSince`) and scores candidates with `distance² / (1 + age * FAIRNESS_K)` — older waiting tasks eventually outweigh proximity.
- Adds `Game.elapsed` (cumulative seconds) as the fairness clock source.

## Test plan
- [ ] Place farms at varying distances from the hive; verify outer-ring farms get serviced within reasonable time
- [ ] Confirm nearby farms still get prompt attention (fairness doesn't over-penalise proximity)
- [ ] Stress-test with many ants to ensure no performance regression from `_updateEligibility()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)