### PR TITLE
feat: instanced rendering for ants and queen (closes #68, #66)

### DIFF
--- a/engine/components/instanced_renderer.js
+++ b/engine/components/instanced_renderer.js
@@ -1,0 +1,45 @@
+import * as THREE from 'three';
+import { Component } from '../gameobject.js';
+import { composeYawMatrix } from '../instanced_mesh_group.js';
+
+/**
+ * Bridges a GameObject's transform into an InstancedMeshGroup.
+ * Each frame it reads position + yaw from the GO and pushes a matrix update
+ * to the shared instanced pool — no per-entity scene-graph subtree needed.
+ */
+export class InstancedRenderer extends Component {
+  /**
+   * @param {import('../instanced_mesh_group.js').InstancedMeshGroup} group
+   */
+  constructor(group) {
+    super();
+    this._group = group;
+    this._id    = -1;
+    this._mat   = new THREE.Matrix4();
+  }
+
+  start() {
+    // Allocate a slot using current transform
+    this._updateMatrix();
+    this._id = this._group.addInstance(this._mat);
+  }
+
+  update(_dt) {
+    if (this._id < 0) return;
+    this._updateMatrix();
+    this._group.setMatrixAt(this._id, this._mat);
+  }
+
+  destroy() {
+    if (this._id >= 0) {
+      this._group.removeInstance(this._id);
+      this._id = -1;
+    }
+  }
+
+  _updateMatrix() {
+    const pos = this.gameObject.position;
+    const yaw = this.gameObject.object3D.rotation.y;
+    composeYawMatrix(this._mat, pos.x, pos.y, pos.z, yaw);
+  }
+}

--- a/engine/instanced_mesh_group.js
+++ b/engine/instanced_mesh_group.js
@@ -1,0 +1,190 @@
+import * as THREE from 'three';
+
+/**
+ * Renders N copies of a pre-loaded GLB model efficiently using THREE.InstancedMesh.
+ * Each sub-mesh in the source model gets its own InstancedMesh; all share a capacity
+ * and free-list so instances can be added/removed without full rebuilds.
+ */
+export class InstancedMeshGroup {
+  /**
+   * @param {THREE.Object3D} sourceScene - the loaded model scene (from model_cache)
+   * @param {object} opts
+   * @param {number} opts.capacity - pre-allocated instance slots (grows on demand)
+   * @param {number} opts.scale - uniform scale baked into the base matrix per part
+   */
+  constructor(sourceScene, { capacity = 256, scale = 1 } = {}) {
+    this.object3D  = new THREE.Group();
+    this._capacity = capacity;
+    this._scale    = scale;
+    this._count    = 0;          // active instance count
+    this._freeList = [];         // recycled slot indices
+    this._meshes   = [];         // { instMesh, baseMatrix }[]
+    this._alive    = new Set();  // active slot indices
+
+    // Zero-scale matrix used to hide inactive slots
+    this._zeroMatrix = new THREE.Matrix4().makeScale(0, 0, 0);
+
+    this._buildFromScene(sourceScene);
+  }
+
+  /** Number of active instances */
+  get count() { return this._count; }
+
+  /**
+   * Add a new instance. Returns an integer ID used for future updates/removal.
+   * @param {THREE.Matrix4} matrix - world transform for this instance
+   * @param {THREE.Color} [color] - optional per-instance tint
+   */
+  addInstance(matrix, color) {
+    let id;
+    if (this._freeList.length > 0) {
+      id = this._freeList.pop();
+    } else {
+      id = this._count + this._freeList.length; // next fresh slot
+      if (id >= this._capacity) this._grow();
+    }
+    this._alive.add(id);
+    this._count++;
+    this.setMatrixAt(id, matrix);
+    if (color) this.setColorAt(id, color);
+    return id;
+  }
+
+  /**
+   * Remove an instance by ID. The slot is recycled.
+   */
+  removeInstance(id) {
+    if (!this._alive.has(id)) return;
+    this._alive.delete(id);
+    this._count--;
+    // Hide the slot
+    for (const { instMesh } of this._meshes) {
+      instMesh.setMatrixAt(id, this._zeroMatrix);
+      instMesh.instanceMatrix.needsUpdate = true;
+    }
+    this._freeList.push(id);
+  }
+
+  /**
+   * Update the world-space transform for an instance.
+   */
+  setMatrixAt(id, matrix) {
+    for (const { instMesh, baseMatrix } of this._meshes) {
+      _composed.multiplyMatrices(matrix, baseMatrix);
+      instMesh.setMatrixAt(id, _composed);
+      instMesh.instanceMatrix.needsUpdate = true;
+    }
+  }
+
+  /**
+   * Update per-instance color tint.
+   */
+  setColorAt(id, color) {
+    for (const { instMesh } of this._meshes) {
+      instMesh.setColorAt(id, color);
+      if (instMesh.instanceColor) instMesh.instanceColor.needsUpdate = true;
+    }
+  }
+
+  dispose() {
+    for (const { instMesh } of this._meshes) {
+      instMesh.dispose();
+    }
+    this._meshes = [];
+    this.object3D.clear();
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────────
+
+  _buildFromScene(sourceScene) {
+    sourceScene.updateWorldMatrix(true, true);
+    const meshes = [];
+    sourceScene.traverse(obj => {
+      if (obj.isMesh) meshes.push(obj);
+    });
+
+    for (const mesh of meshes) {
+      const geom = mesh.geometry;
+      const mat  = mesh.material.clone();
+      const instMesh = new THREE.InstancedMesh(geom, mat, this._capacity);
+      instMesh.castShadow    = true;
+      instMesh.receiveShadow = true;
+      instMesh.frustumCulled = false; // managed manually
+      instMesh.count = this._capacity; // always render full capacity (hidden via zero-scale)
+
+      // Bake the mesh's local transform + the desired uniform scale into a
+      // base matrix that's composed with each instance's world matrix.
+      const baseMatrix = new THREE.Matrix4();
+      mesh.updateWorldMatrix(true, false);
+      baseMatrix.copy(mesh.matrixWorld);
+      baseMatrix.scale(new THREE.Vector3(this._scale, this._scale, this._scale));
+
+      // Initialize all slots to zero-scale (hidden)
+      for (let i = 0; i < this._capacity; i++) {
+        instMesh.setMatrixAt(i, this._zeroMatrix);
+      }
+      instMesh.instanceMatrix.needsUpdate = true;
+
+      this.object3D.add(instMesh);
+      this._meshes.push({ instMesh, baseMatrix });
+    }
+  }
+
+  _grow() {
+    const newCap = this._capacity * 2;
+    for (const entry of this._meshes) {
+      const old = entry.instMesh;
+      const inst = new THREE.InstancedMesh(old.geometry, old.material, newCap);
+      inst.castShadow    = true;
+      inst.receiveShadow = true;
+      inst.frustumCulled = false;
+      inst.count = newCap;
+
+      // Copy existing matrices
+      for (let i = 0; i < this._capacity; i++) {
+        old.getMatrixAt(i, _composed);
+        inst.setMatrixAt(i, _composed);
+      }
+      // Zero-init new slots
+      for (let i = this._capacity; i < newCap; i++) {
+        inst.setMatrixAt(i, this._zeroMatrix);
+      }
+      inst.instanceMatrix.needsUpdate = true;
+
+      // Copy instance colors if present
+      if (old.instanceColor) {
+        const col = new THREE.Color();
+        for (let i = 0; i < this._capacity; i++) {
+          old.getColorAt(i, col);
+          inst.setColorAt(i, col);
+        }
+        if (inst.instanceColor) inst.instanceColor.needsUpdate = true;
+      }
+
+      this.object3D.remove(old);
+      old.dispose();
+      this.object3D.add(inst);
+      entry.instMesh = inst;
+    }
+    this._capacity = newCap;
+  }
+}
+
+// Shared temp matrix to avoid per-call allocations
+const _composed = new THREE.Matrix4();
+
+/**
+ * Helper: build a world matrix from position + yaw + uniform scale.
+ * Writes into the provided Matrix4 `out` and returns it.
+ */
+export function composeYawMatrix(out, x, y, z, yaw = 0, scale = 1) {
+  const c = Math.cos(yaw), s = Math.sin(yaw);
+  // Column-major: rotation around Y, then scale, then translate
+  out.set(
+    c * scale,  0, -s * scale, 0,
+    0,          scale, 0,      0,
+    s * scale,  0,  c * scale, 0,
+    x,          y,  z,         1,
+  );
+  return out;
+}

--- a/engine/model_cache.js
+++ b/engine/model_cache.js
@@ -23,6 +23,11 @@ export function cloneModel(url) {
   return clone;
 }
 
+// Returns the cached scene for a previously loaded model (no clone).
+export function getModelScene(url) {
+  return _cache.get(url) ?? null;
+}
+
 // Max horizontal extent (max of bbox.x, bbox.z) of a preloaded model.
 export function measureModelFootprint(url) {
   const scene = _cache.get(url);

--- a/engine/world_loader.js
+++ b/engine/world_loader.js
@@ -20,7 +20,7 @@ export class WorldLoader {
     for (const e of (data.entities ?? [])) {
       const def = this._defs.get(e.id);
       if (!def) { console.warn(`WorldLoader: unknown entity "${e.id}"`); continue; }
-      const go = def.createObject();
+      const go = def.createObject(game);
 
       if (this._hexGrid && def.occupiesHex) {
         // Snap buildings to the nearest hex center and reserve the hex

--- a/game/components/building.js
+++ b/game/components/building.js
@@ -45,7 +45,7 @@ export class Building extends Component {
 
     // Enter placement mode. On cancel, restore at old position.
     placement.start(def, () => {/* move is free */}, () => {
-      const go = def.createObject();
+      const go = def.createObject(game);
       go.object3D.position.copy(oldPos);
       game.add(go);
       game.hexGrid.occupy(oldHex.q, oldHex.r);

--- a/game/components/queen.js
+++ b/game/components/queen.js
@@ -167,7 +167,7 @@ export class Queen extends Component {
     const def  = ENTITY_DEFS.find(d => d.id === 'egg');
     if (!def) return;
 
-    const go = def.createObject();
+    const go = def.createObject(game);
     go.object3D.position.copy(this.gameObject.object3D.position);
     game.add(go);
   }

--- a/game/components/training_hut.js
+++ b/game/components/training_hut.js
@@ -41,7 +41,7 @@ export class TrainingHut extends Component {
     const def  = ENTITY_DEFS.find(d => d.id === 'ant');
     if (!def || !game) return;
 
-    const go = def.createObject();
+    const go = def.createObject(game);
     go.object3D.position.copy(this.gameObject.object3D.position);
     game.add(go);
   }

--- a/game/entities.js
+++ b/game/entities.js
@@ -2,6 +2,7 @@ import { EntityDef } from '../engine/entity_def.js';
 import { GameObject } from '../engine/gameobject.js';
 import { loadModel, cloneModel } from '../engine/model_cache.js';
 import { Mover } from '../engine/components/mover.js';
+import { InstancedRenderer } from '../engine/components/instanced_renderer.js';
 import { GOAPAgent } from '../engine/ai/goap/goap_agent.js';
 import { ResourceNode } from './components/resource_node.js';
 import { Worker } from './components/worker.js';
@@ -86,27 +87,23 @@ export const ENTITY_DEFS = [
   new EntityDef({
     id: 'ant', name: 'Ant', icon: '🐜', iconUrl: 'assets/icons/Ant.png', yOffset: 0,
     modelUrl: 'assets/models/Ant.glb',
-    createObject() {
+    createObject(game) {
       const go = new GameObject('Ant');
-      const model = cloneModel(this.modelUrl);
-      model.scale.setScalar(0.25);
-      go.object3D.add(model);
       go.addComponent(new Mover(1.5));
       go.addComponent(new GOAPAgent());
       go.addComponent(new Worker());
+      if (game?.antInstances) go.addComponent(new InstancedRenderer(game.antInstances));
       return go;
     },
   }),
   new EntityDef({
     id: 'queen', name: 'Queen', icon: '👑', iconUrl: 'assets/icons/Queen.png',
     modelUrl: 'assets/models/Queen.glb',
-    createObject() {
+    createObject(game) {
       const go = new GameObject('Queen');
-      const model = cloneModel(this.modelUrl);
-      model.scale.setScalar(0.4);
-      go.object3D.add(model);
       go.addComponent(new Mover(1.0));
       go.addComponent(new Queen());
+      if (game?.queenInstances) go.addComponent(new InstancedRenderer(game.queenInstances));
       return go;
     },
   }),

--- a/game/main.js
+++ b/game/main.js
@@ -4,7 +4,8 @@ import { CameraRig } from '../engine/components/camera_rig.js';
 import { DirectionalLight } from '../engine/components/directional_light.js';
 import { WorldLoader } from '../engine/world_loader.js';
 import { ENTITY_DEFS, preloadEntityModels } from './entities.js';
-import { loadModel, measureModelFootprint } from '../engine/model_cache.js';
+import { loadModel, measureModelFootprint, getModelScene } from '../engine/model_cache.js';
+import { InstancedMeshGroup } from '../engine/instanced_mesh_group.js';
 import { HexGrid } from '../engine/hex/hex_grid.js';
 import { HexGridRenderer } from '../engine/components/hex_grid_renderer.js';
 import { Resources } from '../engine/resources.js';
@@ -63,6 +64,14 @@ await Promise.all([
   loadModel('assets/models/FeedingTray.glb'),
   loadModel('assets/models/HoneyBlob.glb'),
 ]);
+
+// Instanced pools for ants and queen — shared across all entities of each type.
+const antInstances = new InstancedMeshGroup(getModelScene('assets/models/Ant.glb'), { capacity: 256, scale: 0.25 });
+const queenInstances = new InstancedMeshGroup(getModelScene('assets/models/Queen.glb'), { capacity: 4, scale: 0.4 });
+game.scene.add(antInstances.object3D);
+game.scene.add(queenInstances.object3D);
+game.antInstances   = antInstances;
+game.queenInstances = queenInstances;
 
 // Hex size = anthill footprint inscribed exactly (flat-to-flat = sqrt(3) * size)
 const anthillFootprint = measureModelFootprint('assets/models/AntHill.glb');

--- a/game/placement_controller.js
+++ b/game/placement_controller.js
@@ -41,7 +41,7 @@ export class PlacementController {
   cancel() { this._cancel(); }
 
   _buildGhost(def) {
-    const go = def.createObject();
+    const go = def.createObject(this._game);
     go.game = this._game;
     go.start();
     this._ghostMats.length = 0;
@@ -100,7 +100,7 @@ export class PlacementController {
     e.stopImmediatePropagation();
 
     const wp = grid.hexToWorld(hex.q, hex.r);
-    const go = this._def.createObject();
+    const go = this._def.createObject(this._game);
     go.object3D.position.set(wp.x, 0, wp.z);
     this._game.add(go);
     grid.occupy(hex.q, hex.r);


### PR DESCRIPTION
## Summary
- Adds `engine/instanced_mesh_group.js` — generic InstancedMesh pool for any GLB model (satisfies Phase 0.3, #66)
- Adds `engine/components/instanced_renderer.js` — component that syncs a GameObject's transform into an instanced pool each frame
- Worker ants share one `InstancedMeshGroup` (capacity 256); queen has her own (capacity 4)
- Carry-item visuals remain as per-ant Object3D clones (hybrid approach — few in number, random rotations)
- All `createObject()` call sites updated to pass `game` so entities can access instanced pools

## How it works
1. After model preload, `main.js` creates `InstancedMeshGroup` pools from the cached ant/queen GLB scenes
2. `entities.js` no longer clones the ant/queen model — instead attaches an `InstancedRenderer` component
3. Each frame, `InstancedRenderer.update()` reads position + yaw and calls `setMatrixAt()` on the pool
4. The GO's `object3D` remains in the scene graph (empty, no mesh) so carry-item children still render correctly

## Test plan
- [ ] Run the game — ants should appear and move normally
- [ ] Verify carry items (sugar blob, branch, etc.) still show on the ant
- [ ] Check draw call count in renderer info (should be significantly lower with many ants)
- [ ] Spawn ~150 ants via Training Hut loop — confirm no visual glitches or performance regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)